### PR TITLE
[OWL-166] Fix error when inserting data into mockcfg table.

### DIFF
--- a/web/model/nodata.py
+++ b/web/model/nodata.py
@@ -71,7 +71,7 @@ class Nodata(Bean):
             'step' : step,
             'mock': mock,
             'creator': login_user,
-            't_create': int(time.time())
+            't_create': time.strftime('%Y-%m-%d %H:%M:%S', time.localtime())
         })
 
         if nodata_id:


### PR DESCRIPTION
MySQL datetime format is '1900-01-01 12:00:00'.
