### PR TITLE
[OWL-182] unify font style with grafana

### DIFF
--- a/web/static/css/g.css
+++ b/web/static/css/g.css
@@ -1,8 +1,3 @@
-body, input, div, span, h1, h2, h3, h4, h5, table, th, td, ul, li, dl,
-dt, dd, a {
-    font-family: 'verdana', 'Microsoft YaHei', 'Consolas',
-    'Deja Vu Sans Mono', 'Bitstream Vera Sans Mono';
-}
 
 .cut-line {
     margin: 0 5px;


### PR DESCRIPTION
### What? Why?

問題點：
portal font-style 與 grafana 字體不同，所導致跑版的問題

portal 原本使用

```
font-family: 'verdana', 'Microsoft YaHei', 'Consolas','Deja Vu Sans Mono', 'Bitstream Vera Sans Mono';
```

grafana 使用

```
font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
```

原本就有宣染grafana 使用的字體，故直接移除 portal 所使用的font style，讓全站font style 一致性相同
### How was it tested?

cc @hitripod 
